### PR TITLE
poistaa ennenaikaisen 'npm start'-komennon

### DIFF
--- a/src/content/osa1/osa1a.md
+++ b/src/content/osa1/osa1a.md
@@ -15,7 +15,6 @@ Luodaan sovellus nimeltään <i>osa1</i> ja mennään sovelluksen sisältämää
 ```bash
 $ npx create-react-app osa1
 $ cd osa1
-$ npm start
 ```
 
 Kaikki tässä (ja jatkossa) annettavat merkillä <em>$</em> alkavat komennot on kirjoitettu terminaaliin eli komentoriville. Merkkiä <em>$</em> ei tule kirjoittaa, sillä se edustaa komentokehoitetta.


### PR DESCRIPTION
Ohjeissa sovellus käynnistetään koukkujen asennuksen jälkeen, ja tätä ennen tapahtuva 'npm start' lähinnä sekoittaa pakkaa.