### PR TITLE
Fix highlighted text in code snippets to be horizontally flush with other text

### DIFF
--- a/src/templates/ContentTemplate.scss
+++ b/src/templates/ContentTemplate.scss
@@ -122,7 +122,7 @@
   margin-right: -1em;
   margin-left: -1em;
   padding-right: 1em;
-  padding-left: 0.75em;
+  padding-left: 1em;
 }
 
 code[class*='language-'],


### PR DESCRIPTION
The highlighted text in code snippets is 0.25em to the left of the other text as shown below:
![image](https://user-images.githubusercontent.com/13034493/51382957-c9335a00-1b20-11e9-919f-61e4f73700c9.png)
This change should fix it (tested on Firefox).
