### PR TITLE
Replaces formatNote(note) calls with note.toJSON()

### DIFF
--- a/src/content/osa3/osa3c.md
+++ b/src/content/osa3/osa3c.md
@@ -612,7 +612,7 @@ Lisätään tilanteeseen yksinkertainen virheidenkäsittelijä:
 app.get('/api/notes/:id', (request, response) => {
   Note.findById(request.params.id)
     .then(note => {
-      response.json(formatNote(note))
+      response.json(note.toJSON())
     })
     .catch(error => {
       console.log(error);
@@ -660,7 +660,7 @@ app.get('/api/notes/:id', (request, response) => {
     .then(note => {
       // highlight-start
       if (note) {
-        response.json(formatNote(note))
+        response.json(note.toJSON())
       } else {
         response.status(404).end() 
       }


### PR DESCRIPTION
Replaces two extinct formatNote() calls left in the examples from last iteration with currently used .toJSON().